### PR TITLE
treewide: Fix incorrect debugfs init error checks

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -757,7 +757,7 @@ config PERF_EVENTS_USERMODE
 
 config PERF_EVENTS_RESET_PMU_DEBUGFS
 	bool "Reset PMU via debugfs node"
-	depends on PERF_EVENTS
+	depends on PERF_EVENTS && DEBUGFS
 	help
 		Enable the debugfs node that can be used to reset PMUs and all
 		state variables associated with PMUs. If enabled, PMU and internal

--- a/arch/arm64/kernel/perf_trace_counters.c
+++ b/arch/arm64/kernel/perf_trace_counters.c
@@ -157,11 +157,11 @@ int __init init_tracecounters(void)
 	int cpu;
 
 	dir = debugfs_create_dir("perf_debug_tp", NULL);
-	if (!dir)
+	if (IS_ERR_OR_NULL(dir))
 		return -ENOMEM;
 	file = debugfs_create_file("enabled", 0660, dir,
 		&value, &fops_perftp);
-	if (!file) {
+	if (IS_ERR_OR_NULL(file)) {
 		debugfs_remove(dir);
 		return -ENOMEM;
 	}

--- a/arch/arm64/kernel/perf_trace_user.c
+++ b/arch/arm64/kernel/perf_trace_user.c
@@ -83,11 +83,11 @@ static int __init init_perf_trace(void)
 	unsigned int value = 1;
 
 	dir = perf_create_debug_dir();
-	if (!dir)
+	if (IS_ERR_OR_NULL(dir))
 		return -ENOMEM;
 	file = debugfs_create_file("trace_marker", S_IWUSR | S_IWGRP, dir,
 		&value, &perf_trace_fops);
-	if (!file)
+	if (IS_ERR_OR_NULL(file))
 		return -ENOMEM;
 
 	return 0;

--- a/drivers/iommu/io-pgtable.c
+++ b/drivers/iommu/io-pgtable.c
@@ -128,11 +128,11 @@ static int io_pgtable_init(void)
 {
 	io_pgtable_top = debugfs_create_dir("io-pgtable", iommu_debugfs_top);
 
-	if (!io_pgtable_top)
+	if (IS_ERR_OR_NULL(io_pgtable_top))
 		return -ENODEV;
 
-	if (!debugfs_create_atomic_t("pages", 0600,
-				     io_pgtable_top, &pages_allocated)) {
+	if (IS_ERR_OR_NULL(debugfs_create_atomic_t("pages", 0600,
+				     io_pgtable_top, &pages_allocated))) {
 		debugfs_remove_recursive(io_pgtable_top);
 		return -ENODEV;
 	}

--- a/drivers/iommu/iommu.c
+++ b/drivers/iommu/iommu.c
@@ -1318,7 +1318,7 @@ static int __init iommu_init(void)
 	BUG_ON(!iommu_group_kset);
 
 	iommu_debugfs_top = debugfs_create_dir("iommu", NULL);
-	if (!iommu_debugfs_top) {
+	if (IS_ERR_OR_NULL(iommu_debugfs_top)) {
 		pr_err("Couldn't create iommu debugfs directory\n");
 		return -ENODEV;
 	}

--- a/drivers/media/platform/msm/camera_v2/isp/msm_isp.c
+++ b/drivers/media/platform/msm/camera_v2/isp/msm_isp.c
@@ -283,18 +283,18 @@ static int msm_isp_enable_debugfs(struct vfe_device *vfe_dev,
 
 	snprintf(dirname, sizeof(dirname), "msm_isp%d", vfe_dev->pdev->id);
 	debugfs_base = debugfs_create_dir(dirname, NULL);
-	if (!debugfs_base)
+	if (IS_ERR_OR_NULL(debugfs_base))
 		return -ENOMEM;
-	if (!debugfs_create_file("stats", S_IRUGO | S_IWUSR, debugfs_base,
-		vfe_dev, &vfe_debugfs_error))
-		return -ENOMEM;
-
-	if (!debugfs_create_file("bw_req_history", S_IRUGO | S_IWUSR,
-		debugfs_base, isp_req_hist, &bw_history_ops))
+	if (IS_ERR_OR_NULL(debugfs_create_file("stats", S_IRUGO | S_IWUSR, debugfs_base,
+		vfe_dev, &vfe_debugfs_error)))
 		return -ENOMEM;
 
-	if (!debugfs_create_file("ub_info", S_IRUGO | S_IWUSR,
-		debugfs_base, vfe_dev, &ub_info_ops))
+	if (IS_ERR_OR_NULL(debugfs_create_file("bw_req_history", S_IRUGO | S_IWUSR,
+		debugfs_base, isp_req_hist, &bw_history_ops)))
+		return -ENOMEM;
+
+	if (IS_ERR_OR_NULL(debugfs_create_file("ub_info", S_IRUGO | S_IWUSR,
+		debugfs_base, vfe_dev, &ub_info_ops)))
 		return -ENOMEM;
 
 	return 0;

--- a/drivers/media/platform/msm/camera_v2/msm.c
+++ b/drivers/media/platform/msm/camera_v2/msm.c
@@ -1339,14 +1339,14 @@ static int msm_probe(struct platform_device *pdev)
 
 	cam_debugfs_root = debugfs_create_dir(MSM_CAM_LOGSYNC_FILE_BASEDIR,
 						NULL);
-	if (!cam_debugfs_root) {
+	if (IS_ERR_OR_NULL(cam_debugfs_root)) {
 		pr_warn("NON-FATAL: failed to create logsync base directory\n");
 	} else {
-		if (!debugfs_create_file(MSM_CAM_LOGSYNC_FILE_NAME,
+		if (IS_ERR_OR_NULL(debugfs_create_file(MSM_CAM_LOGSYNC_FILE_NAME,
 					 0666,
 					 cam_debugfs_root,
 					 NULL,
-					 &logsync_fops))
+					 &logsync_fops)))
 			pr_warn("NON-FATAL: failed to create logsync debugfs file\n");
 	}
 

--- a/drivers/media/platform/msm/camera_v2/pproc/cpp/msm_cpp.c
+++ b/drivers/media/platform/msm/camera_v2/pproc/cpp/msm_cpp.c
@@ -4342,11 +4342,11 @@ static int msm_cpp_enable_debugfs(struct cpp_device *cpp_dev)
 {
 	struct dentry *debugfs_base;
 	debugfs_base = debugfs_create_dir("msm_cpp", NULL);
-	if (!debugfs_base)
+	if (IS_ERR_OR_NULL(debugfs_base))
 		return -ENOMEM;
 
-	if (!debugfs_create_file("error", S_IRUGO | S_IWUSR, debugfs_base,
-		(void *)cpp_dev, &cpp_debugfs_error))
+	if (IS_ERR_OR_NULL(debugfs_create_file("error", S_IRUGO | S_IWUSR, debugfs_base,
+		(void *)cpp_dev, &cpp_debugfs_error)))
 		return -ENOMEM;
 
 	return 0;

--- a/drivers/power/qcom/msm-pm.c
+++ b/drivers/power/qcom/msm-pm.c
@@ -814,7 +814,7 @@ static int msm_cpu_pm_probe(struct platform_device *pdev)
 		dent = debugfs_create_file("pc_debug_counter", S_IRUGO, NULL,
 				msm_pc_debug_counters,
 				&msm_pc_debug_counters_fops);
-		if (!dent)
+		if (IS_ERR_OR_NULL(dent))
 			pr_err("%s: ERROR debugfs_create_file failed\n",
 					__func__);
 		res = platform_get_resource(pdev, IORESOURCE_MEM, 0);

--- a/drivers/power/qpnp-smbcharger.c
+++ b/drivers/power/qpnp-smbcharger.c
@@ -8604,7 +8604,7 @@ static int create_debugfs_entries(struct smbchg_chip *chip)
 	struct dentry *ent;
 
 	chip->debug_root = debugfs_create_dir("qpnp-smbcharger", NULL);
-	if (!chip->debug_root) {
+	if (IS_ERR_OR_NULL(chip->debug_root)) {
 		dev_err(chip->dev, "Couldn't create debug dir\n");
 		return -EINVAL;
 	}
@@ -8613,7 +8613,7 @@ static int create_debugfs_entries(struct smbchg_chip *chip)
 				  S_IFREG | S_IWUSR | S_IRUGO,
 				  chip->debug_root, chip,
 				  &force_dcin_icl_ops);
-	if (!ent) {
+	if (IS_ERR_OR_NULL(ent)) {
 		dev_err(chip->dev,
 			"Couldn't create force dcin icl check file\n");
 		return -EINVAL;

--- a/drivers/regulator/core.c
+++ b/drivers/regulator/core.c
@@ -1230,7 +1230,7 @@ static struct regulator *create_regulator(struct regulator_dev *rdev,
 
 	regulator->debugfs = debugfs_create_dir(regulator->supply_name,
 						rdev->debugfs);
-	if (!regulator->debugfs) {
+	if (IS_ERR_OR_NULL(regulator->debugfs)) {
 		rdev_warn(rdev, "Failed to create debugfs directory\n");
 	} else {
 		debugfs_create_u32("uA_load", 0444, regulator->debugfs,
@@ -4511,7 +4511,7 @@ static int __init regulator_init(void)
 	ret = class_register(&regulator_class);
 
 	debugfs_root = debugfs_create_dir("regulator", NULL);
-	if (!debugfs_root)
+	if (IS_ERR_OR_NULL(debugfs_root))
 		pr_warn("regulator: Failed to create debugfs directory\n");
 
 	debugfs_create_file("supply_map", 0444, debugfs_root, NULL,

--- a/drivers/soc/qcom/glink_debugfs.c
+++ b/drivers/soc/qcom/glink_debugfs.c
@@ -182,7 +182,7 @@ static struct glink_dbgfs_data *glink_dfs_create_file(const char *name,
 		dfs_d->b_priv_free_req = b_free_req;
 	}
 	file = debugfs_create_file(name, 0400, parent, dfs_d, &debug_ops);
-	if (!file)
+	if (IS_ERR_OR_NULL(file))
 		GLINK_DBG("%s: unable to create file '%s'\n", __func__,
 				name);
 	dfs_d->dent = file;
@@ -690,7 +690,7 @@ struct dentry *glink_debugfs_create(const char *name,
 	if (parent != NULL) {
 		if (dir->b_dir_create) {
 			dent = debugfs_create_dir(name, parent);
-			if (dent != NULL)
+			if (!IS_ERR_OR_NULL(dent))
 				glink_dfs_update_list(dent, parent,
 							c_dir_name, p_dir_name);
 		} else {

--- a/drivers/staging/android/binder.c
+++ b/drivers/staging/android/binder.c
@@ -3687,11 +3687,11 @@ static int __init binder_init(void)
 		return -ENOMEM;
 
 	binder_debugfs_dir_entry_root = debugfs_create_dir("binder", NULL);
-	if (binder_debugfs_dir_entry_root)
+	if (!IS_ERR_OR_NULL(binder_debugfs_dir_entry_root))
 		binder_debugfs_dir_entry_proc = debugfs_create_dir("proc",
 						 binder_debugfs_dir_entry_root);
 	ret = misc_register(&binder_miscdev);
-	if (binder_debugfs_dir_entry_root) {
+	if (!IS_ERR_OR_NULL(binder_debugfs_dir_entry_root)) {
 		debugfs_create_file("state",
 				    S_IRUGO,
 				    binder_debugfs_dir_entry_root,

--- a/drivers/staging/android/ion/ion.c
+++ b/drivers/staging/android/ion/ion.c
@@ -993,7 +993,8 @@ struct ion_client *ion_client_create(struct ion_device *dev,
 	client->debug_root = debugfs_create_file(client->display_name, 0664,
 						dev->clients_debug_root,
 						client, &debug_client_fops);
-	if (!client->debug_root) {
+	if (IS_ERR_OR_NULL(client->debug_root) &&
+		!IS_ERR_OR_NULL(dev->clients_debug_root)) {
 		char buf[256], *path;
 
 		path = dentry_path(dev->clients_debug_root, buf, 256);
@@ -1987,7 +1988,8 @@ void ion_device_add_heap(struct ion_device *dev, struct ion_heap *heap)
 					dev->heaps_debug_root, heap,
 					&debug_heap_fops);
 
-	if (!debug_file) {
+	if (IS_ERR_OR_NULL(debug_file) &&
+		!IS_ERR_OR_NULL(dev->heaps_debug_root)) {
 		char buf[256], *path;
 
 		path = dentry_path(dev->heaps_debug_root, buf, 256);
@@ -2003,7 +2005,8 @@ void ion_device_add_heap(struct ion_device *dev, struct ion_heap *heap)
 		debug_file = debugfs_create_file(
 			debug_name, 0644, dev->heaps_debug_root, heap,
 			&debug_shrink_fops);
-		if (!debug_file) {
+		if (IS_ERR_OR_NULL(debug_file) &&
+			!IS_ERR_OR_NULL(dev->heaps_debug_root)) {
 			char buf[256], *path;
 
 			path = dentry_path(dev->heaps_debug_root, buf, 256);
@@ -2062,18 +2065,18 @@ struct ion_device *ion_device_create(long (*custom_ioctl)
 	}
 
 	idev->debug_root = debugfs_create_dir("ion", NULL);
-	if (!idev->debug_root) {
+	if (IS_ERR_OR_NULL(idev->debug_root)) {
 		pr_err("ion: failed to create debugfs root directory.\n");
 		goto debugfs_done;
 	}
 	idev->heaps_debug_root = debugfs_create_dir("heaps", idev->debug_root);
-	if (!idev->heaps_debug_root) {
+	if (IS_ERR_OR_NULL(idev->heaps_debug_root)) {
 		pr_err("ion: failed to create debugfs heaps directory.\n");
 		goto debugfs_done;
 	}
 	idev->clients_debug_root = debugfs_create_dir("clients",
 						idev->debug_root);
-	if (!idev->clients_debug_root)
+	if (IS_ERR_OR_NULL(idev->clients_debug_root))
 		pr_err("ion: failed to create debugfs clients directory.\n");
 
 debugfs_done:

--- a/drivers/staging/qcacld-2.0/CORE/HDD/src/wlan_hdd_debugfs.c
+++ b/drivers/staging/qcacld-2.0/CORE/HDD/src/wlan_hdd_debugfs.c
@@ -613,19 +613,19 @@ VOS_STATUS hdd_debugfs_init(hdd_adapter_t *pAdapter)
     hdd_context_t *pHddCtx = WLAN_HDD_GET_CTX(pAdapter);
     pHddCtx->debugfs_phy = debugfs_create_dir("wlan_wcnss", 0);
 
-    if (NULL == pHddCtx->debugfs_phy)
+    if (IS_ERR_OR_NULL(pHddCtx->debugfs_phy))
         return VOS_STATUS_E_FAILURE;
 
-    if (NULL == debugfs_create_file("wow_enable", S_IRUSR | S_IWUSR,
-        pHddCtx->debugfs_phy, pAdapter, &fops_wowenable))
+    if (IS_ERR_OR_NULL(debugfs_create_file("wow_enable", S_IRUSR | S_IWUSR,
+        pHddCtx->debugfs_phy, pAdapter, &fops_wowenable)))
         return VOS_STATUS_E_FAILURE;
 
-    if (NULL == debugfs_create_file("wow_pattern", S_IRUSR | S_IWUSR,
-        pHddCtx->debugfs_phy, pAdapter, &fops_wowpattern))
+    if (IS_ERR_OR_NULL(debugfs_create_file("wow_pattern", S_IRUSR | S_IWUSR,
+        pHddCtx->debugfs_phy, pAdapter, &fops_wowpattern)))
         return VOS_STATUS_E_FAILURE;
 
-    if (NULL == debugfs_create_file("pattern_gen", S_IRUSR | S_IWUSR,
-        pHddCtx->debugfs_phy, pAdapter, &fops_patterngen))
+    if (IS_ERR_OR_NULL(debugfs_create_file("pattern_gen", S_IRUSR | S_IWUSR,
+        pHddCtx->debugfs_phy, pAdapter, &fops_patterngen)))
         return VOS_STATUS_E_FAILURE;
 
     return VOS_STATUS_SUCCESS;

--- a/drivers/staging/qcacld-2.0/CORE/HDD/src/wlan_hdd_ipa.c
+++ b/drivers/staging/qcacld-2.0/CORE/HDD/src/wlan_hdd_ipa.c
@@ -5007,7 +5007,7 @@ static int hdd_ipa_debugfs_init(struct hdd_ipa_priv *hdd_ipa)
 #ifdef WLAN_OPEN_SOURCE
 	hdd_ipa->debugfs_dir = debugfs_create_dir("cld" SUFFIX,
 					hdd_ipa->hdd_ctx->wiphy->debugfsdir);
-	if (!hdd_ipa->debugfs_dir)
+	if (IS_ERR_OR_NULL(hdd_ipa->debugfs_dir))
 		return -ENOMEM;
 
 	debugfs_create_file("ipa-stats", S_IRUSR, hdd_ipa->debugfs_dir,
@@ -5149,7 +5149,8 @@ VOS_STATUS hdd_ipa_init(hdd_context_t *hdd_ctx)
 
 	ret = hdd_ipa_debugfs_init(hdd_ipa);
 	if (ret)
-		goto fail_alloc_rx_pipe_desc;
+		HDD_IPA_LOG(VOS_TRACE_LEVEL_ERROR,
+			"hdd_ipa_debugfs_init failed");
 
 	if (!hdd_ipa_uc_is_enabled(hdd_ipa)) {
 		hdd_ipa->ipv4_notifier.notifier_call = hdd_ipa_ipv4_changed;

--- a/drivers/staging/qcacld-2.0/CORE/UTILS/FWLOG/dbglog_host.c
+++ b/drivers/staging/qcacld-2.0/CORE/UTILS/FWLOG/dbglog_host.c
@@ -4306,7 +4306,7 @@ int dbglog_debugfs_init(wmi_unified_t wmi_handle)
 {
 
     wmi_handle->debugfs_phy = debugfs_create_dir(CLD_DEBUGFS_DIR, NULL);
-    if (!wmi_handle->debugfs_phy)
+    if (IS_ERR_OR_NULL(wmi_handle->debugfs_phy))
         return -ENOMEM;
 
     debugfs_create_file(DEBUGFS_BLOCK_NAME, S_IRUSR, wmi_handle->debugfs_phy, &wmi_handle->dbglog,

--- a/drivers/usb/core/usb.c
+++ b/drivers/usb/core/usb.c
@@ -1068,13 +1068,13 @@ static struct dentry *usb_debug_devices;
 static int usb_debugfs_init(void)
 {
 	usb_debug_root = debugfs_create_dir("usb", NULL);
-	if (!usb_debug_root)
+	if (IS_ERR_OR_NULL(usb_debug_root))
 		return -ENOENT;
 
 	usb_debug_devices = debugfs_create_file("devices", 0444,
 						usb_debug_root, NULL,
 						&usbfs_devices_fops);
-	if (!usb_debug_devices) {
+	if (IS_ERR_OR_NULL(usb_debug_devices)) {
 		debugfs_remove(usb_debug_root);
 		usb_debug_root = NULL;
 		return -ENOENT;
@@ -1101,9 +1101,8 @@ static int __init usb_init(void)
 	}
 	usb_init_pool_max();
 
-	retval = usb_debugfs_init();
-	if (retval)
-		goto out;
+	usb_debugfs_init();
+
 
 	usb_acpi_register();
 	retval = bus_register(&usb_bus_type);

--- a/drivers/usb/gadget/debug.c
+++ b/drivers/usb/gadget/debug.c
@@ -103,7 +103,7 @@ int debug_debugfs_init(void)
 	int			ret;
 
 	root = debugfs_create_dir("debug", NULL);
-	if (!root) {
+	if (IS_ERR_OR_NULL(root)) {
 		ret = -ENOMEM;
 		goto err0;
 	}
@@ -112,7 +112,7 @@ int debug_debugfs_init(void)
 
 	file = debugfs_create_file("read_buf", S_IRUGO, root,
 			NULL, &dbg_read_buf_fops);
-	if (!file) {
+	if (IS_ERR_OR_NULL(file)) {
 		ret = -ENOMEM;
 		goto err1;
 	}

--- a/drivers/usb/mon/mon_text.c
+++ b/drivers/usb/mon/mon_text.c
@@ -680,7 +680,7 @@ int mon_text_add(struct mon_bus *mbus, const struct usb_bus *ubus)
 			goto err_print_t;
 		d = debugfs_create_file(name, 0600, mon_dir, mbus,
 							     &mon_fops_text_t);
-		if (d == NULL)
+		if (IS_ERR_OR_NULL(d))
 			goto err_create_t;
 		mbus->dent_t = d;
 	}
@@ -689,7 +689,7 @@ int mon_text_add(struct mon_bus *mbus, const struct usb_bus *ubus)
 	if (rc <= 0 || rc >= NAMESZ)
 		goto err_print_u;
 	d = debugfs_create_file(name, 0600, mon_dir, mbus, &mon_fops_text_u);
-	if (d == NULL)
+	if (IS_ERR_OR_NULL(d))
 		goto err_create_u;
 	mbus->dent_u = d;
 
@@ -697,7 +697,7 @@ int mon_text_add(struct mon_bus *mbus, const struct usb_bus *ubus)
 	if (rc <= 0 || rc >= NAMESZ)
 		goto err_print_s;
 	d = debugfs_create_file(name, 0600, mon_dir, mbus, &mon_fops_stat);
-	if (d == NULL)
+	if (IS_ERR_OR_NULL(d))
 		goto err_create_s;
 	mbus->dent_s = d;
 

--- a/sound/soc/codecs/wcd_cpe_core.c
+++ b/sound/soc/codecs/wcd_cpe_core.c
@@ -1684,24 +1684,24 @@ static int wcd_cpe_debugfs_init(struct wcd_cpe_core *core)
 		goto err_create_dir;
 	}
 
-	if (!debugfs_create_u32("ramdump_enable", S_IRUGO | S_IWUSR,
-				dir, &ramdump_enable)) {
+	if (IS_ERR_OR_NULL(debugfs_create_u32("ramdump_enable", S_IRUGO | S_IWUSR,
+				dir, &ramdump_enable))) {
 		dev_err(core->dev, "%s: Failed to create debugfs node %s\n",
 			__func__, "ramdump_enable");
 		rc = -ENODEV;
 		goto err_create_entry;
 	}
 
-	if (!debugfs_create_file("cpe_ftm_test_trigger", S_IWUSR,
-				dir, core, &cpe_ftm_test_trigger_fops)) {
+	if (IS_ERR_OR_NULL(debugfs_create_file("cpe_ftm_test_trigger", S_IWUSR,
+				dir, core, &cpe_ftm_test_trigger_fops))) {
 		dev_err(core->dev, "%s: Failed to create debugfs node %s\n",
 			__func__, "cpe_ftm_test_trigger");
 		rc = -ENODEV;
 		goto err_create_entry;
 	}
 
-	if (!debugfs_create_u32("cpe_ftm_test_status", S_IRUGO,
-				dir, &cpe_ftm_test_status)) {
+	if (IS_ERR_OR_NULL(debugfs_create_u32("cpe_ftm_test_status", S_IRUGO,
+				dir, &cpe_ftm_test_status))) {
 		dev_err(core->dev, "%s: Failed to create debugfs node %s\n",
 			__func__, "cpe_ftm_test_status");
 		rc = -ENODEV;


### PR DESCRIPTION
When CONFIG_DEBUGFS is disabled, all of the debugfs functions that return
a pointer are hardcoded to return ERR_PTR(-ENODEV). This causes debugfs
error checks in many drivers to not work correctly because they only check
to see if the return value is NULL, rather than checking to see if it is
NULL or contains an error code.

This fixes the incorrect debugfs error check assumptions, as well as fixes
init routines where debugfs failure was treated as a fatal error (so that
the drivers will still work when CONFIG_DEBUGFS is disabled).

Signed-off-by: Sultanxda <sultanxda@gmail.com>